### PR TITLE
soc/intel/meteorlake: Set UsbTcPortEn based on tcss_port[x] (ported from alderlake)

### DIFF
--- a/src/soc/intel/meteorlake/fsp_params.c
+++ b/src/soc/intel/meteorlake/fsp_params.c
@@ -421,13 +421,6 @@ static void fill_fsps_igd_params(FSP_S_CONFIG *s_cfg,
 static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,
 		const struct soc_intel_meteorlake_config *config)
 {
-	const struct device *tcss_port_arr[] = {
-		DEV_PTR(tcss_usb3_port0),
-		DEV_PTR(tcss_usb3_port1),
-		DEV_PTR(tcss_usb3_port2),
-		DEV_PTR(tcss_usb3_port3),
-	};
-
 	s_cfg->TcssAuxOri = config->tcss_aux_ori;
 
 	/* Explicitly clear this field to avoid using defaults */
@@ -438,8 +431,8 @@ static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,
 	s_cfg->D3ColdEnable = CONFIG(D3COLD_SUPPORT);
 	s_cfg->UsbTcPortEn = 0;
 
-	for (int i = 0; i < MAX_TYPE_C_PORTS; i++) {
-		if (is_dev_enabled(tcss_port_arr[i]))
+	for (int i = 0; i < ARRAY_SIZE(config->tcss_ports); i++) {
+		if (config->tcss_ports[i].enable)
 			s_cfg->UsbTcPortEn |= BIT(i);
 	}
 


### PR DESCRIPTION
Looks like for the Darter Pro 10 (Meteor Lake) there is the same bug with the usb3 solved in https://github.com/system76/coreboot/pull/227 for Raptor Lake and Alder Lake.

So I just ported the code to Meteor Lake, but I was not be able to test it yet. Can someone confirm that the patch is working?

Seams to be related to https://github.com/system76/firmware-open/issues/511 and https://github.com/system76/firmware-open/issues/497 but both using Raptor Lake so it seams to be fixed after the patch. Here is the related https://github.com/system76/firmware-open/pull/556.